### PR TITLE
[TASK] containerFactory breaking name change + V13 composer compat

### DIFF
--- a/Classes/DataProcessing/HeadlessContainerProcessor.php
+++ b/Classes/DataProcessing/HeadlessContainerProcessor.php
@@ -41,7 +41,7 @@ class HeadlessContainerProcessor extends ContainerProcessor
         }
 
         try {
-            $container = $this->containerFactory->buildContainer($contentId);
+            $container = $this->frontendContainerFactory->buildContainer($cObj, $this->context, $contentId);
         } catch (Exception $e) {
             // do nothing
             return $processedData;

--- a/Classes/DataProcessing/HeadlessContainerProcessor.php
+++ b/Classes/DataProcessing/HeadlessContainerProcessor.php
@@ -7,6 +7,7 @@ namespace Fanor51\HeadlessContainerSupport\DataProcessing;
 use B13\Container\DataProcessing\ContainerProcessor;
 use B13\Container\Domain\Factory\Exception;
 use FriendsOfTYPO3\Headless\DataProcessing\DataProcessingTrait;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class HeadlessContainerProcessor extends ContainerProcessor
@@ -41,7 +42,12 @@ class HeadlessContainerProcessor extends ContainerProcessor
         }
 
         try {
-            $container = $this->frontendContainerFactory->buildContainer($cObj, $this->context, $contentId);
+            $majorVersion = explode('.', ExtensionManagementUtility::getExtensionVersion('container'))[0];
+            if ((int)$majorVersion >= 3) {
+                $container = $this->frontendContainerFactory->buildContainer($cObj, $this->context, $contentId);
+            } else {
+                $container = $this->containerFactory->buildContainer($contentId);
+            }
         } catch (Exception $e) {
             // do nothing
             return $processedData;

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": "^8.0",
-    "typo3/cms-core": "^11.5 || ^12.4",
-    "b13/container": "^1.6 || ^2.0",
-    "friendsoftypo3/headless": "^3.0 || ^4.0 || dev-master"
+    "typo3/cms-core": "^13.4",
+    "b13/container": "^3.0",
+    "friendsoftypo3/headless": "^4.0 || dev-master"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": "^8.0",
-    "typo3/cms-core": "^13.4",
-    "b13/container": "^3.0",
-    "friendsoftypo3/headless": "^4.0 || dev-master"
+    "typo3/cms-core": "^11.5 || ^12.4 || ^13.4",
+    "b13/container": "^1.6 || ^2.0 || ^3.1.2",
+    "friendsoftypo3/headless": "^3.0 || ^4.0 || dev-master"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
Hello,

Starting v13 compatibility with this MR

b13/container upgraded to 3.x, but implemented a breaking change for `$this->containerFactory` now called `$this->frontendContainerFactory`. It also need additional parameters. (see 3.1.2 [commit](https://github.com/b13/container/pull/575/commits/fa1bb983c4c3c4a1f6e68dc803809160d60e0829))

Does v13 has to support older versions of TYPO3 ? 
How can it be done with this breaking change ?